### PR TITLE
improve config root parsing

### DIFF
--- a/src/setuptools_scm/__main__.py
+++ b/src/setuptools_scm/__main__.py
@@ -22,7 +22,7 @@ def main() -> None:
             f" Reason: {ex}.",
             file=sys.stderr,
         )
-        config = Configuration(root=opts.root or ".")
+        config = Configuration(root=opts.root)
 
     version = _get_version(config)
     assert version is not None

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -34,6 +34,8 @@ def test_config_from_pyproject(tmpdir):
         textwrap.dedent(
             """
             [tool.setuptools_scm]
+            root = "../.."
+
             [project]
             description = "Factory ⸻ A code generator 🏭"
             authors = [{name = "Łukasz Langa"}]
@@ -41,7 +43,9 @@ def test_config_from_pyproject(tmpdir):
         ),
         encoding="utf-8",
     )
-    assert Configuration.from_file(str(fn))
+    config = Configuration.from_file(str(fn))
+    assert config
+    assert config.root == "../.."
 
 
 def test_config_regex_init():

--- a/testing/test_git.py
+++ b/testing/test_git.py
@@ -95,7 +95,7 @@ def test_parse_call_order(wd):
 def test_version_from_git(wd):
     assert wd.version == "0.1.dev0"
 
-    assert git.parse(str(wd.cwd), git.DEFAULT_DESCRIBE).branch == "master"
+    assert git.parse(str(wd.cwd), git.DEFAULT_DESCRIBE).branch in ("master", "main")
 
     wd.commit_testfile()
     assert wd.version.startswith("0.1.dev1+g")

--- a/testing/test_main.py
+++ b/testing/test_main.py
@@ -60,3 +60,55 @@ def test_repo_with_pyproject_missing_setuptools_scm(repo):
     repo.add_and_commit()
     res = repo((sys.executable, "-m", "setuptools_scm"))
     assert res.startswith("0.1.1.dev2")
+
+
+@pytest.fixture
+def subpkg_repo(repo):
+    p = repo.cwd / "sub" / "pkg"
+    p.mkdir(parents=True)
+    repo.write(
+        "sub/pkg/pyproject.toml",
+        textwrap.dedent(
+            """
+            [tool.setuptools_scm]
+            root = "../.."
+            """
+        )
+    )
+    repo.add_and_commit()
+    yield repo
+
+
+def test_repo_with_pyproject_root(subpkg_repo):
+    subpkg_repo.cwd = subpkg_repo.cwd / "sub" / "pkg"
+    res = subpkg_repo((sys.executable, "-m", "setuptools_scm"))
+    assert res.startswith("0.1.1.dev2")
+
+
+def test_repo_cmdline_root_supersedes_config(repo):
+    p = repo.cwd / "sub" / "pkg"
+    p.mkdir(parents=True)
+    repo.cwd = p
+    repo.write(
+        "pyproject.toml",
+        textwrap.dedent(
+            """
+            [tool.setuptools_scm]
+            root = "."
+            """
+        )
+    )
+    repo.add_and_commit()
+    res = repo((sys.executable, "-m", "setuptools_scm", "-r", "../.."))
+    assert res.startswith("0.1.1.dev2")
+
+
+def test_repo_pyproject_root_relative_file(subpkg_repo):
+    res = subpkg_repo((sys.executable, "-m", "setuptools_scm", "-c", "sub/pkg/pyproject.toml"))
+    assert res.startswith("0.1.1.dev2")
+
+
+def test_repo_cmdline_root_relative_cwd(subpkg_repo):
+    subpkg_repo.cwd = subpkg_repo.cwd / "sub"
+    res = subpkg_repo((sys.executable, "-m", "setuptools_scm", "-c", "pkg/pyproject.toml", "-r", "../"))
+    assert res.startswith("0.1.1.dev2")


### PR DESCRIPTION
* match handling of `dist_name` to improve readability
* avoid `relpath` to resolve config dir while constructing root path
  this improves compatibility with windows
* assume root is relative to config file when read from pyproject.toml
* add tests